### PR TITLE
Add support to stringified JSONs as properties and compound resource_id for hosts

### DIFF
--- a/monasca_persister/README.rst
+++ b/monasca_persister/README.rst
@@ -13,8 +13,11 @@ This parser processes monitoring data from `Monasca Persister`_ formatted as
         "timestamp": number,        // = metric.timestamp in milliseconds
         "name": "str",              // = metric.name, UTF8-encoded
         "value": ...,               // = metric.value
-        "value_meta": {
-          "key": "value"
+        "value_meta": {             // = metric.value_meta with stringified values
+          "<key#1>": "str",
+          "<key#2>": "str",
+          ...
+          "properties": "{\"key\": value}"
         },
         "dimensions": {
           "<name#1>": "str",        // = metric.dimensions[#1]
@@ -33,7 +36,7 @@ This parser processes monitoring data from `Monasca Persister`_ formatted as
 Those data points are mapped to NGSI Entities according to the following:
 
 .. list-table:: **Entity Type = 'region'
-                  (Id taken from '_region' dimension)**
+                  (Id taken from 'region' meta item)**
    :widths: 30 20 15 20 15
    :header-rows: 1
 
@@ -124,7 +127,7 @@ file.
 |
 
 .. list-table:: **Entity Type = 'host_service'
-                  (Id taken from '_region' and 'component' dimensions)**
+                  (Id taken from 'region' meta item and 'component' dimension)**
    :widths: 30 20 15 20 15
    :header-rows: 1
 
@@ -146,7 +149,7 @@ of an OpenStack service (given by the 'service' dimension, e.g. `nova`).
 |
 
 .. list-table:: **Entity Type = 'host'
-                  (Id taken from '_region' and 'resource_id' dimensions)**
+                  (Id taken from 'region' meta item and 'resource_id' dimension)**
    :widths: 30 20 15 20 15
    :header-rows: 1
 
@@ -194,7 +197,7 @@ of an OpenStack service (given by the 'service' dimension, e.g. `nova`).
 |
 
 .. list-table:: **Entity Type = 'vm'
-                  (Id taken from '_region' and 'resource_id' dimensions)**
+                  (Id taken from 'region' meta item and 'resource_id' dimension)**
    :widths: 30 20 15 20 15
    :header-rows: 1
 
@@ -236,4 +239,4 @@ Taken from 'user_id' and 'project_id' dimensions, respectively.
 
 .. REFERENCES
 
-.. _Monasca Persister: https://github.com/openstack/monasca-persister/
+.. _Monasca Persister: https://github.com/telefonicaid/monasca-persister/

--- a/monasca_persister/lib/monasca_persister_data_point.js
+++ b/monasca_persister/lib/monasca_persister_data_point.js
@@ -108,7 +108,7 @@ parser.parseRequest = function (reqdomain) {
         reqdomain.entityId = region;
     } else if (name.indexOf('compute.node.') === 0) {
         reqdomain.entityType = 'host';
-        reqdomain.entityId = util.format('%s:%s', region, dimensions['resource_id']);
+        reqdomain.entityId = util.format('%s:%s', region, dimensions['resource_id'].replace(/^(.*)_\1$/, '$1'));
     } else if (name === 'image') {
         reqdomain.entityType = 'image';
         reqdomain.entityId = util.format('%s:%s', region, dimensions['resource_id']);

--- a/monasca_persister/lib/monasca_persister_data_point.js
+++ b/monasca_persister/lib/monasca_persister_data_point.js
@@ -74,8 +74,11 @@ var parser = Object.create(null);
  *             "timestamp": number,                 // = metric.timestamp in milliseconds
  *             "name": "str",                       // = metric.name, UTF8-encoded
  *             "value": ...,                        // = metric.value
- *             "value_meta": {
- *               "key": "value"
+ *             "value_meta": {                      // = metric.value_meta with stringified values
+ *               "<key#1>": "str",
+ *               "<key#2>": "str",
+ *               ...
+ *               "properties": "{\"key\": value}"
  *             },
  *             "dimensions": {
  *               "<name#1>": "str",                 // = metric.dimensions[#1]
@@ -140,6 +143,15 @@ parser.getContextAttrs = function (entityData) {
         valueMeta = entityData.data.metric['value_meta'],
         item;
 
+    // Unmarshal stringified value of 'properties' metadata item
+    if (valueMeta && valueMeta['properties']) {
+        try {
+            valueMeta['properties'] = JSON.parse(valueMeta['properties']);
+        } catch (e) {
+            delete valueMeta['properties'];
+        }
+    }
+
     // Initially map data point 'value' field as a NGSI attribute with the same name of the measurement (i.e. metric)
     var attrName = entityData.data.metric['name'],
         attrValue = entityData.data.metric['value'];
@@ -151,8 +163,10 @@ parser.getContextAttrs = function (entityData) {
         }
     } else if (entityData.entityType === 'image') {
         for (item in valueMeta) {
-            if (valueMeta[item].hasOwnProperty('nid')) {
-                attrs[metricsMappingNGSI['nid']] = valueMeta[item]['nid'];
+            if (item === 'properties') {
+                if (valueMeta[item].hasOwnProperty('nid')) {
+                    attrs[metricsMappingNGSI['nid']] = valueMeta[item]['nid'];
+                }
             } else {
                 attrs[item] = valueMeta[item];
             }
@@ -164,8 +178,10 @@ parser.getContextAttrs = function (entityData) {
             }
         }
         for (item in valueMeta) {
-            if (valueMeta[item].hasOwnProperty('nid')) {
-                attrs[metricsMappingNGSI['nid']] = valueMeta[item]['nid'];
+            if (item === 'properties') {
+                if (valueMeta[item].hasOwnProperty('nid')) {
+                    attrs[metricsMappingNGSI['nid']] = valueMeta[item]['nid'];
+                }
             } else {
                 attrs[metricsMappingNGSI[item] || item] = valueMeta[item];
             }

--- a/monasca_persister/test/unit/sample_data_point_host.json
+++ b/monasca_persister/test/unit/sample_data_point_host.json
@@ -6,7 +6,7 @@
     "value": 5,
     "dimensions": {
       "project_id": "00000000000000000000000000000001",
-      "resource_id": "b6dd5d1a-5754-40d4-81af-ed947e97e6a4"
+      "resource_id": "myhost_myhost"
     }
   },
   "meta": {

--- a/monasca_persister/test/unit/sample_data_point_image.json
+++ b/monasca_persister/test/unit/sample_data_point_image.json
@@ -6,10 +6,7 @@
     "value": 1,
     "value_meta": {
       "status": "active",
-      "properties": {
-        "type": "fiware:apps",
-        "nid": "194"
-      },
+      "properties": "{\"type\":\"fiware:apps\",\"nid\":\"194\"}",
       "name": "wirecloud",
       "size": 1156972544
     },

--- a/monasca_persister/test/unit/sample_data_point_region.json
+++ b/monasca_persister/test/unit/sample_data_point_region.json
@@ -5,6 +5,10 @@
     "name": "region.used_ip",
     "value": 25,
     "dimensions": {
+      "resource_id": "myregion",
+      "source": "openstack",
+      "type": "gauge",
+      "unit": "#"
     }
   },
   "meta": {

--- a/monasca_persister/test/unit/sample_data_point_vm.json
+++ b/monasca_persister/test/unit/sample_data_point_vm.json
@@ -10,9 +10,7 @@
       "status": "active",
       "image_ref": "713ee693-882c-4259-b0f8-99623aab810c",
       "instance_type": "2",
-      "properties": {
-        "nid": "71"
-      }
+      "properties": "{\"nid\": \"71\"}"
     },
     "dimensions": {
       "source": "openstack",

--- a/monasca_persister/test/unit/test_parser.js
+++ b/monasca_persister/test/unit/test_parser.js
@@ -198,12 +198,12 @@ suite('parser', function () {
         }
     });
 
-    test('context_attrs_include_custom_catalogue_id_of_data_point_image', function () {
+    test('context_attrs_include_custom_catalogue_id_property_of_data_point_image', function () {
         var type = 'image',
             data = require('./sample_data_point_' + type + '.json'),
             valueMeta = data.metric['value_meta'],
             expectedAttr = metricsMappingNGSI['nid'],
-            expectedValue = valueMeta.properties['nid'],
+            expectedValue = valueMeta['properties'].replace(/.*"nid":.*"(\w+)".*/, '$1'),
             reqdomain = {
                 body: JSON.stringify(data)
             };
@@ -211,6 +211,34 @@ suite('parser', function () {
             contextAttrs = parser.getContextAttrs(entityData);
         assert(contextAttrs[expectedAttr]);
         assert.equal(contextAttrs[expectedAttr], expectedValue);
+    });
+
+    test('context_attrs_ignore_other_custom_value_meta_property_of_data_point_image', function () {
+        var type = 'image',
+            data = require('./sample_data_point_' + type + '.json'),
+            valueMeta = data.metric['value_meta'],
+            attrMeta = 'custom';
+        valueMeta['properties'] = util.format('{"%s": "value"}', attrMeta);
+        var reqdomain = {
+                body: JSON.stringify(data)
+            };
+        var entityData = parser.parseRequest(reqdomain),
+            contextAttrs = parser.getContextAttrs(entityData);
+        assert.equal(contextAttrs[attrMeta], undefined);
+    });
+
+    test('context_attrs_ignore_invalid_json_in_value_meta_properties_of_data_point_image', function () {
+        var type = 'image',
+            data = require('./sample_data_point_' + type + '.json'),
+            valueMeta = data.metric['value_meta'],
+            attrMeta = metricsMappingNGSI['nid'];
+        valueMeta['properties'] = '{invalid json, "nid": 123}';
+        var reqdomain = {
+                body: JSON.stringify(data)
+            };
+        var entityData = parser.parseRequest(reqdomain),
+            contextAttrs = parser.getContextAttrs(entityData);
+        assert.equal(contextAttrs[attrMeta], undefined);
     });
 
     test('parse_gets_valid_entity_type_of_data_point_host', function () {
@@ -329,7 +357,7 @@ suite('parser', function () {
             data = require('./sample_data_point_' + type + '.json'),
             valueMeta = data.metric['value_meta'],
             expectedAttr = metricsMappingNGSI['nid'],
-            expectedValue = valueMeta.properties['nid'],
+            expectedValue = valueMeta['properties'].replace(/.*"nid":.*"(\w+)".*/, '$1'),
             reqdomain = {
                 body: JSON.stringify(data)
             };
@@ -337,6 +365,20 @@ suite('parser', function () {
             contextAttrs = parser.getContextAttrs(entityData);
         assert(contextAttrs[expectedAttr]);
         assert.equal(contextAttrs[expectedAttr], expectedValue);
+    });
+
+    test('context_attrs_ignore_other_custom_value_meta_property_of_data_point_vm', function () {
+        var type = 'vm',
+            data = require('./sample_data_point_' + type + '.json'),
+            valueMeta = data.metric['value_meta'],
+            attrMeta = 'custom';
+        valueMeta['properties'] = util.format('{"%s": "value"}', attrMeta);
+        var reqdomain = {
+                body: JSON.stringify(data)
+            };
+        var entityData = parser.parseRequest(reqdomain),
+            contextAttrs = parser.getContextAttrs(entityData);
+        assert.equal(contextAttrs[attrMeta], undefined);
     });
 
 });

--- a/monasca_persister/test/unit/test_parser.js
+++ b/monasca_persister/test/unit/test_parser.js
@@ -255,13 +255,29 @@ suite('parser', function () {
         var type = 'host',
             data = require('./sample_data_point_' + type + '.json'),
             region = data.meta['region'],
-            resource = data.metric.dimensions['resource_id'],
-            expectedIdPattern = util.format('%s:%s', region, resource),
+            resource = data.metric.dimensions['resource_id'],  /* resource == host_nodename (usually same values) */
+            host = resource.split('_')[0],
+            expectedId = util.format('%s:%s', region, host),
             reqdomain = {
                 body: JSON.stringify(data)
             };
         parser.parseRequest(reqdomain);
-        assert(reqdomain.entityId.match(new RegExp(expectedIdPattern)));
+        assert.equal(reqdomain.entityId, expectedId);
+    });
+
+    test('parse_gets_valid_entity_id_with_host_and_nodename_of_data_point_host', function () {
+        var type = 'host',
+            data = require('./sample_data_point_' + type + '.json'),
+            region = data.meta['region'],
+            host = 'myhost',
+            nodename = 'mynodename';
+        data.metric.dimensions['resource_id'] = util.format('%s_%s', host, nodename);
+        var expectedId = util.format('%s:%s_%s', region, host, nodename),
+            reqdomain = {
+                body: JSON.stringify(data)
+            };
+        parser.parseRequest(reqdomain);
+        assert.equal(reqdomain.entityId, expectedId);
     });
 
     test('context_attrs_include_standard_metrics_of_data_point_host', function () {


### PR DESCRIPTION
#### Reviewers

@jesuspg 
#### Description
- Add support to stringified JSONs as properties in value metadata (restriction of Monasca API)
- Add support to 'host_nodename' resource_id in hosts (format used by Ceilometer)
#### Testing

Verified in FIWARE Lab.
